### PR TITLE
Add `.dockerignore`

### DIFF
--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -169,6 +169,8 @@ TAGS="v1"
 
 DH_IMAGE="${HOST}/${USER}/${DH}:${TAGS}"
 
+echo "/target" >> .dockerignore
+
 docker build \
 --tag=${DH_IMAGE} \
 --file=./Dockerfile.discovery-handler \


### PR DESCRIPTION
Unfortunately `cargo new ...` creates a `.gitignore` but not a `.dockerignore`.

`docker build ...`  sends the `.` to the docker daemon:

+ Without `.dockerignore`,  (`.` includes `/target`) it sends 1.89GB).
+ With `.dockerignore`, it sends 129.5kB

The difference is local but it saves time and is (has become my) good practice.